### PR TITLE
Postgres database migration, resolves issue with long item names

### DIFF
--- a/editor-webapp/src/main/resources/db/migration/V3__title_text_length.sql
+++ b/editor-webapp/src/main/resources/db/migration/V3__title_text_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE input_queue ALTER COLUMN name TYPE TEXT;
+ALTER TABLE digital_object ALTER COLUMN name TYPE TEXT;


### PR DESCRIPTION
issue https://github.com/moravianlibrary/MEditor/issues/64

After DB migration, item was correctly with 'long name' ingested into krameriusTest http://krameriustest.mzk.cz/search/i.jsp?pid=uuid:7d343111-5e41-422e-b681-e9dbc1952d96